### PR TITLE
a minor improvement to capture_output

### DIFF
--- a/lib/fezzik.rb
+++ b/lib/fezzik.rb
@@ -45,7 +45,8 @@ namespace :fezzik do
     output = StringIO.new
     $stdout = output
     block.call
+    return output.string
+  ensure
     $stdout = STDOUT
-    output.string
   end
 end


### PR DESCRIPTION
This ensures that stdout is restored in case the block that capture_output calls does something bad.
