### PR TITLE
added missing require

### DIFF
--- a/lib/fezzik.rb
+++ b/lib/fezzik.rb
@@ -1,3 +1,5 @@
+require "stringio"
+
 namespace :fezzik do
   task :run do
     destination = ARGV[0]


### PR DESCRIPTION
added a `require "stringio"` to prevent `'const_missing': uninitialized constant StringIO (NameError)`
