### PR TITLE
Let's get rid of 'sudo gem install' from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and gets out of your way.
 
 ## Install
 
-    sudo gem install fezzik
+    gem install fezzik
 
 ## Setup
 


### PR DESCRIPTION
Out with the old, in with the new!
