### PR TITLE
Exit

### DIFF
--- a/bin/fez
+++ b/bin/fez
@@ -94,7 +94,14 @@ def run_fezzik_tasks
       Rake::Task["fezzik:#{task_name}"].invoke(params)
     end
     puts Fezzik.color_string("[success]", :green)
-  rescue SystemExit, Rake::CommandFailedError => e
+  rescue SystemExit => e
+    if e.status == 0
+      puts Fezzik.color_string("[success]", :green)
+    else
+      puts Fezzik.color_string("[fail]", :red)
+      exit e.status
+    end
+  rescue Rake::CommandFailedError => e
     puts Fezzik.color_string("[fail]", :red)
     exit 1
   rescue StandardError => e

--- a/lib/fezzik/version.rb
+++ b/lib/fezzik/version.rb
@@ -1,3 +1,3 @@
 module Fezzik
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end


### PR DESCRIPTION
If a command calls exit with a status of 0, it should not be displayed as "fail".
