### PR TITLE
We should use the current domain setting, even if it has changed

### DIFF
--- a/fezzik.gemspec
+++ b/fezzik.gemspec
@@ -24,7 +24,7 @@ EOS
   s.files = `git ls-files`.split("\n")
 
   s.add_dependency "rake"
-  s.add_dependency "weave", "=0.1.0"
+  s.add_dependency "weave", "=0.2.0"
 
   s.add_development_dependency("scope", "~>0.2.3")
 end

--- a/lib/fezzik/host_task.rb
+++ b/lib/fezzik/host_task.rb
@@ -18,10 +18,10 @@ module Fezzik
 
       if @roles.empty?
         hosts = Fezzik.get(:domain).map { |domain| "#{Fezzik.get(:user)}@#{domain}" }
-        @@connection_pool ||= Weave.connect(hosts)
+        @@connection_pool ||= Weave::ConnectionPool.new
         @host_actions.each do |action|
           begin
-            @@connection_pool.execute(:args => [self, args], &action)
+            @@connection_pool.execute_with(hosts, :args => [self, args], &action)
           rescue Weave::Error => e
             STDERR.puts "Error running command in HostTask '#{@name}':"
             abort e.message
@@ -32,10 +32,10 @@ module Fezzik
           Fezzik.with_role(role) do
             hosts = Fezzik.get(:domain).map { |domain| "#{Fezzik.get(:user)}@#{domain}" }
             @@role_connection_pools ||= {}
-            @@role_connection_pools[role] ||= Weave.connect(hosts)
+            @@role_connection_pools[role] ||= Weave::ConnectionPool.new
             @host_actions.each do |action|
               begin
-                @@role_connection_pools[role].execute(:args => [self, args], &action)
+                @@role_connection_pools[role].execute_with(hosts, :args => [self, args], &action)
               rescue Weave::Error => e
                 STDERR.puts "Error running command in HostTask '#{@name}' with role '#{role}':"
                 abort e.message

--- a/lib/fezzik/version.rb
+++ b/lib/fezzik/version.rb
@@ -1,3 +1,3 @@
 module Fezzik
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Right now, we create one `Weave::ConnectionPool` (or rather, weave does for us) and then even if the host list changes, we'll keep using the same hosts for subsequent `host_task`s.

Interestingly, the same behavior was present before 0.8.0, even though it used rake remote task instead.

I've changed Weave to have an additional method, `ConnectionPool#execute_with`, that allows for specifying the host list. You can just make an empty `ConnectionPool` and then add hosts when you need them.

These changes are all that is necessary to make Fezzik take advantage of that.

You can see an example of the bad behavior I experienced here:

https://gist.github.com/cespare/6ae5aeb00a2f3030dfc9
